### PR TITLE
fix: Using && operator and updating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "homepage": "https://github.com/grupo0003/register-Employees-Products-#readme",
   "dependencies": {
-    "cpf-cnpj-validator": "^1.0.3",
     "@joi/date": "^2.1.0",
     "dotenv": "^14.2.0",
     "express": "^4.17.2",

--- a/src/app/helper/isCpf.js
+++ b/src/app/helper/isCpf.js
@@ -2,7 +2,7 @@ function isValid (cpfNumber) {
   let sum = 0
   let rest
 
-  if (cpfNumber === '00000000000' || cpfNumber.length !== 11) return false
+  if (cpfNumber === '00000000000' && cpfNumber.length !== 11) return false
 
   for (let i = 1; i <= 9; i++) sum = sum + parseInt(cpfNumber.substring(i - 1, i)) * (11 - i)
   rest = (sum * 10) % 11


### PR DESCRIPTION
Operator || replaced by && and CPF-Validator dependency deleted